### PR TITLE
feat: 감정 바퀴 UI 추가

### DIFF
--- a/auth/src/services/emotionService.ts
+++ b/auth/src/services/emotionService.ts
@@ -2,7 +2,7 @@ import { collection, doc, getDocs, getDoc, setDoc, updateDoc, query, orderBy, Ti
 import { db } from '../firebase';
 import { BASE_CATEGORIES, COMPOSITE_CATEGORIES } from '@shared/constants/categories';
 import { resolveIntensityByName, IntensityLevel } from '@shared/constants/plutchikIntensity';
-import type { Emotion, VisibilityCondition } from '@shared/types/api';
+import type { Emotion } from '@shared/types/api';
 
 interface IntensityConfig {
   [key: string]: {

--- a/host/src/App.tsx
+++ b/host/src/App.tsx
@@ -1,11 +1,12 @@
 import React, { Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ToastHost from './components/ToastHost';
 import { useRememberProgress } from 'cart/features/remembering/hooks/useRememberProgress';
 import { useRememberingSync } from 'cart/features/remembering/hooks/useRememberingSync';
 import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
+import { useAuthStore } from 'auth/authStore';
 import './styles/tailwind.css';
 
 const Header = lazy(() => import('header/Header'));
@@ -29,6 +30,9 @@ const queryClient = new QueryClient({
 });
 
 function AppContent() {
+  const location = useLocation();
+  const user = useAuthStore((state) => state.user);
+
   useRememberingSync();
   useRememberProgress();
 

--- a/products/src/ProductList.tsx
+++ b/products/src/ProductList.tsx
@@ -30,9 +30,9 @@ const ENERGY_STATES: SortDirection[] = ['asc', 'desc', null];
 const ENERGY_LABELS: Record<string, string> = { asc: '낮은순', desc: '높은순' };
 const ARROW: Record<string, string> = { asc: '↑', desc: '↓' };
 const INTENSITY_LABELS: Record<string, string> = {
-  low: 'Low',
-  middle: 'Middle',
   high: 'High',
+  middle: 'Middle',
+  low: 'Low',
 };
 
 function loadSortPrefs(): SortPrefs {
@@ -131,6 +131,11 @@ function ProductList() {
     [addToCart]
   );
 
+  const cartProductIds = React.useMemo(
+    () => new Set(Object.values(cartItems).map((item) => item.product.id)),
+    [cartItems]
+  );
+
   const handleProductClick = (id: number) => {
     navigate(`/detail/${id}`);
   };
@@ -138,7 +143,7 @@ function ProductList() {
   return (
     <div className="mx-auto max-w-[1400px] px-3 md:px-5">
       <div className="flex flex-col md:flex-row md:items-center gap-4">
-        <div className="flex relative">
+        <div className="flex relative z-10">
           {/* 현재 조건 */}
           <CurrentConditionUI view={view} />
           
@@ -330,6 +335,7 @@ function ProductList() {
               emotions={emotions}
               conditions={conditions}
               onAddToCart={handleAddToCart}
+              cartProductIds={cartProductIds}
             />
           )}
         </>

--- a/products/src/__tests__/ProductList.test.tsx
+++ b/products/src/__tests__/ProductList.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, beforeEach, vi } from 'vitest';
 import { Timestamp } from 'firebase/firestore';
@@ -70,7 +71,10 @@ describe('ProductList', () => {
   it('API 데이터로 상품 카드가 렌더링된다', async () => {
     renderWithProviders(<ProductList />);
 
-    expect(screen.getByLabelText('products-search')).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText('view-mode-list'));
+
+    expect(await screen.findByLabelText('products-search')).toBeInTheDocument();
     expect(screen.getByLabelText('products-sort-energy')).toBeInTheDocument();
     expect(screen.getByLabelText('products-filter-collection')).toBeInTheDocument();
     expect(await screen.findByLabelText('product-card-1')).toBeInTheDocument();

--- a/products/src/components/ConditionHintPopup.tsx
+++ b/products/src/components/ConditionHintPopup.tsx
@@ -7,8 +7,9 @@ import {
 } from '../utils/conditions';
 
 interface EmotionLike {
-  emoji?: string;
-  visibility?: VisibilityCondition;
+  emoji: string;
+  published: boolean;
+  visibility: VisibilityCondition;
 }
 
 interface Props {
@@ -187,7 +188,7 @@ function ConditionHintPopup({ emotions, conditions, isOpen, onClose }: Props): R
                     : 'bg-[var(--color-overlay-2)] opacity-50'
                 }`}
               >
-                <div className="flex min-w-0 items-center gap-2">
+                <div className="flex shrink-0 items-center gap-2">
                   {group.isMet ? (
                     <Check size={16} className="shrink-0 text-[var(--color-accent-green)]" />
                   ) : (
@@ -195,7 +196,7 @@ function ConditionHintPopup({ emotions, conditions, isOpen, onClose }: Props): R
                   )}
                   <span className="shrink-0 text-sm">{group.conditionLabel}:</span>
                 </div>
-                <div className="flex flex-wrap justify-end gap-1 text-[var(--color-text-muted)]">
+                <div className="flex flex-1 flex-wrap justify-end gap-1 text-[var(--color-text-muted)]">
                   {group.isMet && group.emotionEmojis.length > 0 ? (
                     group.emotionEmojis.map((emoji, i) => (
                       <span key={i} className="text-base text-[var(--color-text-primary)]">

--- a/products/src/components/PlutchikWheel.tsx
+++ b/products/src/components/PlutchikWheel.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState, useCallback, useRef } from 'react';
+import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 import { X } from 'lucide-react';
 import { Emotion } from 'auth/services/emotionService';
@@ -15,12 +16,14 @@ import {
 import {
   CATEGORY_LABELS,
   COMPOSITE_CATEGORY_PAIRS,
+  getIntensityLabel,
 } from '@shared/constants/categories';
 
 interface PlutchikWheelProps {
   emotions: Emotion[] | undefined;
   conditions: CurrentConditions;
   onAddToCart: (emotion: Emotion) => void;
+  cartProductIds?: Set<number>;
 }
 
 interface SegmentData {
@@ -49,13 +52,22 @@ interface SelectedInfo {
   position: { x: number; y: number };
 }
 
-function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps): React.ReactElement {
+interface SectorClickState {
+  sectorIndex: number;
+  clickCount: number;
+}
+
+const CLICK_CONFIRM_DELAY = 1000;
+
+function PlutchikWheel({ emotions, conditions, onAddToCart, cartProductIds }: PlutchikWheelProps): React.ReactElement {
   const [selectedInfo, setSelectedInfo] = useState<SelectedInfo | null>(null);
-  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const [hoveredSector, setHoveredSector] = useState<number | null>(null);
+  const [hoveredComposite, setHoveredComposite] = useState<string | null>(null);
+  const [sectorClickState, setSectorClickState] = useState<SectorClickState | null>(null);
+  const sectorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const segments = useMemo((): SegmentData[] => {
     if (!emotions) return [];
-
     const result: SegmentData[] = [];
     for (let si = 0; si < PLUTCHIK_SECTORS.length; si++) {
       const sector = PLUTCHIK_SECTORS[si];
@@ -83,41 +95,91 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
 
   const composites = useMemo((): CompositeData[] => {
     if (!emotions) return [];
-
-    return Object.entries(COMPOSITE_CATEGORY_PAIRS).map(([category, _pair]) => {
+    return Object.entries(COMPOSITE_CATEGORY_PAIRS).map(([category, pair]) => {
       const matching = emotions.filter((e) => e.category === category);
       const visible = matching.filter((e) => isEmotionVisible(e, conditions));
-      const sectorIndex = PLUTCHIK_SECTORS.findIndex(
-        (s) => s.category === _pair[0]
-      );
-      return {
-        category,
-        emotions: matching,
-        visibleEmotions: visible,
-        position: getCompositePosition(sectorIndex),
-        sectorIndex,
-      };
+      const sectorIndex = PLUTCHIK_SECTORS.findIndex((s) => s.category === pair[0]);
+      return { category, emotions: matching, visibleEmotions: visible, position: getCompositePosition(sectorIndex), sectorIndex };
     });
   }, [emotions, conditions]);
 
-  const handleSegmentClick = useCallback(
-    (segment: SegmentData) => {
-      if (segment.emotions.length === 0) return;
-      if (segment.visibleEmotions.length === 0) {
+  const segmentInCart = useCallback(
+    (segment: SegmentData): boolean => {
+      if (!cartProductIds || cartProductIds.size === 0) return false;
+      return segment.visibleEmotions.some((e) => cartProductIds.has(e.id));
+    },
+    [cartProductIds]
+  );
+
+  // Confirm: map clickCount to ring and add to cart or show popup
+  const confirmSectorSelection = useCallback(
+    (sectorIndex: number, clickCount: number) => {
+      if (!emotions) return;
+      const sector = PLUTCHIK_SECTORS[sectorIndex];
+      // 1 click → low (ringIndex 2), 2 → middle (1), 3 → high (0)
+      const ringIndex = RING_NAMES.length - clickCount;
+      const intensity = RING_NAMES[ringIndex];
+
+      const matching = emotions.filter(
+        (e) => e.category === sector.category && e.intensity === intensity
+      );
+      const visible = matching.filter((e) => isEmotionVisible(e, conditions));
+
+      if (matching.length === 0) return;
+      if (visible.length === 0) {
         toast.info('현재 조건에서는 이 감정이 보이지 않아요');
         return;
       }
-      const label =
-        (CATEGORY_LABELS[segment.category] ?? segment.category) +
-        ` (${segment.intensity})`;
-      setSelectedInfo({
-        emotions: segment.visibleEmotions,
-        label,
-        position: segment.centroid,
-      });
+      if (visible.length === 1) {
+        onAddToCart(visible[0]);
+      } else {
+        const label = getIntensityLabel(sector.category, ringIndex);
+        setSelectedInfo({
+          emotions: visible,
+          label: label ? `${label.ko} (${label.en})` : (CATEGORY_LABELS[sector.category] ?? sector.category),
+          position: getSegmentCentroid(sectorIndex, ringIndex),
+        });
+      }
     },
-    [onAddToCart]
+    [emotions, conditions, onAddToCart]
   );
+
+  // Sector-level click: cycles 1→2→3 within the same sector
+  const handleSectorClick = useCallback(
+    (sectorIndex: number) => {
+      const sector = PLUTCHIK_SECTORS[sectorIndex];
+      if (!emotions?.some((e) => e.category === sector.category)) return;
+
+      setSectorClickState((prev) => ({
+        sectorIndex,
+        clickCount: prev && prev.sectorIndex === sectorIndex
+          ? (prev.clickCount % 3) + 1
+          : 1,
+      }));
+    },
+    [emotions]
+  );
+
+  // Auto-confirm after delay
+  useEffect(() => {
+    if (!sectorClickState) return;
+    if (sectorTimerRef.current) clearTimeout(sectorTimerRef.current);
+
+    sectorTimerRef.current = setTimeout(() => {
+      confirmSectorSelection(sectorClickState.sectorIndex, sectorClickState.clickCount);
+      setSectorClickState(null);
+    }, CLICK_CONFIRM_DELAY);
+
+    return () => {
+      if (sectorTimerRef.current) clearTimeout(sectorTimerRef.current);
+    };
+  }, [sectorClickState, confirmSectorSelection]);
+
+  useEffect(() => {
+    return () => {
+      if (sectorTimerRef.current) clearTimeout(sectorTimerRef.current);
+    };
+  }, []);
 
   const handleCompositeClick = useCallback(
     (composite: CompositeData) => {
@@ -132,7 +194,7 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
         position: composite.position,
       });
     },
-    [onAddToCart]
+    []
   );
 
   const handleKeyDown = useCallback(
@@ -151,14 +213,29 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
     return 0.85;
   };
 
+  const getPreSelectedRing = (sectorIndex: number): number | null => {
+    if (!sectorClickState || sectorClickState.sectorIndex !== sectorIndex) return null;
+    return RING_NAMES.length - sectorClickState.clickCount;
+  };
+
+  const preSelectionLabel = useMemo(() => {
+    if (!sectorClickState) return null;
+    const { sectorIndex, clickCount } = sectorClickState;
+    const ringIndex = RING_NAMES.length - clickCount;
+    const label = getIntensityLabel(PLUTCHIK_SECTORS[sectorIndex].category, ringIndex);
+    return label ? { ko: label.ko, en: label.en, clickCount } : null;
+  }, [sectorClickState]);
+
   const segmentKey = (s: SegmentData) => `${s.category}-${s.intensity}`;
 
+  // Size controls
   const SIZE_MIN = 400;
   const SIZE_MAX = 1200;
   const SIZE_STEP = 100;
   const [wheelSize, setWheelSize] = useState(700);
   const sizeLevel = Math.min(9, Math.max(1, Math.round((wheelSize - SIZE_MIN) / SIZE_STEP) + 1));
 
+  // Drag state
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const dragRef = useRef<{ startX: number; startY: number; startOx: number; startOy: number } | null>(null);
@@ -196,7 +273,7 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
     setWheelSize((s) => Math.min(SIZE_MAX, Math.max(SIZE_MIN, s + delta)));
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const el = svgRef.current;
     if (!el) return;
     el.addEventListener('wheel', handleWheel, { passive: false });
@@ -205,7 +282,7 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
 
   return (
     <div className="flex flex-col items-center -translate-y-8 select-none">
-      <div className="mb-3 flex items-center gap-2 relative z-10 bg-[#121626]/80 rounded-full p-1">
+      <div className="mb-3 fixed -top-12 flex items-center gap-2 z-10 bg-[#121626]/80 rounded-full p-1">
         <button
           onClick={() => setWheelSize((s) => Math.max(SIZE_MIN, s - SIZE_STEP))}
           disabled={wheelSize <= SIZE_MIN}
@@ -226,6 +303,7 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
           +
         </button>
       </div>
+
       <svg
         ref={svgRef}
         viewBox={`0 0 ${VIEW_SIZE + 100} ${VIEW_SIZE + 100}`}
@@ -241,112 +319,173 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
           {/* Segments */}
           {segments.map((segment) => {
             const key = segmentKey(segment);
-            const isHovered = hoveredKey === key;
-            const opacity = getSegmentOpacity(segment);
+            const isSectorHovered = hoveredSector === segment.sectorIndex;
+            const preSelectedRing = getPreSelectedRing(segment.sectorIndex);
+            const isPreSelected = preSelectedRing === segment.ringIndex;
+            const inCart = segmentInCart(segment);
+            const baseOpacity = getSegmentOpacity(segment);
             const hasEmotions = segment.emotions.length > 0;
+
+            let opacity = baseOpacity;
+            if (inCart) opacity = 1;
+            if (isSectorHovered && hasEmotions) opacity = Math.min(opacity + 0.1, 1);
+            if (isPreSelected) opacity = 1;
+
+            const strokeColor = isPreSelected ? '#fff' : 'none';
+            const strokeWidth = isPreSelected ? 2.5 : 0;
 
             return (
               <g key={key}>
                 <path
                   d={segment.path}
                   fill={segment.color}
-                  stroke="var(--color-bg-primary)"
-                  strokeWidth={1.5}
-                  opacity={isHovered && hasEmotions ? Math.min(opacity + 0.15, 1) : opacity}
+                  stroke={strokeColor}
+                  strokeWidth={strokeWidth}
+                  opacity={opacity}
                   className={`outline-none${hasEmotions ? ' cursor-pointer' : ''}`}
                   style={{
                     transition: 'opacity 0.15s ease, filter 0.15s ease',
-                    filter:
-                      isHovered && hasEmotions
-                        ? 'brightness(1.15)'
-                        : 'brightness(1)',
+                    filter: isPreSelected
+                      ? 'brightness(1.25)'
+                      : inCart
+                        ? 'brightness(1.15) saturate(1.4) drop-shadow(0 0 4px rgba(255,255,255,0.4))'
+                        : isSectorHovered && hasEmotions
+                          ? 'brightness(1.1)'
+                          : 'brightness(1)',
                   }}
                   role="button"
                   tabIndex={hasEmotions ? 0 : -1}
                   aria-label={`${CATEGORY_LABELS[segment.category] ?? segment.category} ${segment.intensity}`}
-                  onClick={() => handleSegmentClick(segment)}
-                  onKeyDown={(e) =>
-                    handleKeyDown(e, () => handleSegmentClick(segment))
-                  }
-                  onMouseEnter={() => setHoveredKey(key)}
-                  onMouseLeave={() => setHoveredKey(null)}
+                  onClick={() => handleSectorClick(segment.sectorIndex)}
+                  onKeyDown={(e) => handleKeyDown(e, () => handleSectorClick(segment.sectorIndex))}
+                  onMouseEnter={() => setHoveredSector(segment.sectorIndex)}
+                  onMouseLeave={() => setHoveredSector(null)}
                 />
-                {/* Category label (Korean + English) */}
-                <text
-                  x={segment.centroid.x}
-                  y={segment.centroid.y - 5}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fontSize={segment.ringIndex === 0 ? 9 : 11}
-                  fill="var(--color-bg-primary)"
-                  fontWeight={600}
-                  pointerEvents="none"
-                  opacity={0.9}
-                >
-                  {CATEGORY_LABELS[segment.category] ?? segment.category}
-                </text>
-                <text
-                  x={segment.centroid.x}
-                  y={segment.centroid.y + 7}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fontSize={segment.ringIndex === 0 ? 7 : 8}
-                  fill="var(--color-bg-primary)"
-                  fontWeight={400}
-                  pointerEvents="none"
-                  opacity={0.6}
-                >
-                  {segment.category}
-                </text>
+                {/* Intensity label (Korean + English) */}
+                {(() => {
+                  const label = getIntensityLabel(segment.category, segment.ringIndex);
+                  return label ? (
+                    <>
+                      <text
+                        x={segment.centroid.x}
+                        y={segment.centroid.y - 4}
+                        textAnchor="middle"
+                        dominantBaseline="central"
+                        fontSize={segment.ringIndex === 0 ? 9 : 11}
+                        fill={segment.ringIndex === 0 ? '#fff' : 'var(--color-bg-primary)'}
+                        fontWeight={600}
+                        pointerEvents="none"
+                        opacity={0.9}
+                      >
+                        {label.ko}
+                      </text>
+                      <text
+                        x={segment.centroid.x}
+                        y={segment.centroid.y + 7}
+                        textAnchor="middle"
+                        dominantBaseline="central"
+                        fontSize={segment.ringIndex === 0 ? 7 : 8}
+                        fill={segment.ringIndex === 0 ? '#fff' : 'var(--color-bg-primary)'}
+                        fontWeight={400}
+                        pointerEvents="none"
+                        opacity={segment.ringIndex === 0 ? 0.8 : 0.6}
+                      >
+                        {label.en}
+                      </text>
+                    </>
+                  ) : null;
+                })()}
               </g>
             );
           })}
 
-          {/* Center decoration — drag handle */}
+          {/* Center circle — drag handle + pre-selection feedback */}
           <circle
             cx={CENTER}
             cy={CENTER}
             r={55}
             fill="var(--color-bg-primary)"
-            stroke="var(--color-border-primary)"
-            strokeWidth={1}
+            stroke={sectorClickState ? 'var(--color-accent-green)' : 'var(--color-border-primary)'}
+            strokeWidth={sectorClickState ? 2 : 1}
             className="touch-none"
-            style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
+            style={{ cursor: isDragging ? 'grabbing' : 'grab', transition: 'stroke 0.2s ease' }}
             onPointerDown={handleCenterPointerDown}
             onPointerMove={handleCenterPointerMove}
             onPointerUp={handleCenterPointerUp}
             onPointerCancel={handleCenterPointerUp}
           />
-          <text
-            x={CENTER}
-            y={CENTER - 8}
-            textAnchor="middle"
-            dominantBaseline="central"
-            fontSize={14}
-            fill="var(--color-text-primary)"
-            fontWeight={500}
-          >
-            감정
-          </text>
-          <text
-            x={CENTER}
-            y={CENTER + 10}
-            textAnchor="middle"
-            dominantBaseline="central"
-            fontSize={11}
-            fill="var(--color-text-muted)"
-          >
-            바퀴
-          </text>
+          {preSelectionLabel ? (
+            <>
+              <text
+                x={CENTER}
+                y={CENTER - 12}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={13}
+                fill="var(--color-accent-green)"
+                fontWeight={600}
+                pointerEvents="none"
+              >
+                {preSelectionLabel.ko}
+              </text>
+              <text
+                x={CENTER}
+                y={CENTER + 4}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={10}
+                fill="var(--color-text-muted)"
+                pointerEvents="none"
+              >
+                {preSelectionLabel.en}
+              </text>
+              <text
+                x={CENTER}
+                y={CENTER + 20}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={9}
+                fill="var(--color-text-faded)"
+                pointerEvents="none"
+              >
+                {'●'.repeat(preSelectionLabel.clickCount)}{'○'.repeat(3 - preSelectionLabel.clickCount)}
+              </text>
+            </>
+          ) : (
+            <>
+              <text
+                x={CENTER}
+                y={CENTER - 8}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={14}
+                fill="var(--color-text-primary)"
+                fontWeight={500}
+                pointerEvents="none"
+              >
+                감정
+              </text>
+              <text
+                x={CENTER}
+                y={CENTER + 10}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={11}
+                fill="var(--color-text-muted)"
+                pointerEvents="none"
+              >
+                바퀴
+              </text>
+            </>
+          )}
 
           {/* Composite labels */}
           {composites.map((composite) => {
             const hasEmotions = composite.emotions.length > 0;
             const isVisible = composite.visibleEmotions.length > 0;
-            const label =
-              CATEGORY_LABELS[composite.category] ?? composite.category;
+            const label = CATEGORY_LABELS[composite.category] ?? composite.category;
             const compositeKey = `composite-${composite.category}`;
-            const isHovered = hoveredKey === compositeKey;
+            const isHovered = hoveredComposite === compositeKey;
 
             return (
               <text
@@ -371,11 +510,9 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
                 tabIndex={hasEmotions ? 0 : -1}
                 aria-label={`복합 감정: ${label}`}
                 onClick={() => handleCompositeClick(composite)}
-                onKeyDown={(e) =>
-                  handleKeyDown(e, () => handleCompositeClick(composite))
-                }
-                onMouseEnter={() => setHoveredKey(compositeKey)}
-                onMouseLeave={() => setHoveredKey(null)}
+                onKeyDown={(e) => handleKeyDown(e, () => handleCompositeClick(composite))}
+                onMouseEnter={() => setHoveredComposite(compositeKey)}
+                onMouseLeave={() => setHoveredComposite(null)}
               >
                 {label}
                 {composite.visibleEmotions.length > 1
@@ -384,67 +521,69 @@ function PlutchikWheel({ emotions, conditions, onAddToCart }: PlutchikWheelProps
               </text>
             );
           })}
-
         </g>
       </svg>
 
-      {/* Selection popup */}
-      {selectedInfo && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setSelectedInfo(null)}
-          aria-label="emotion-select-overlay"
-        >
+      {/* Selection popup (multiple emotions at same intensity) */}
+      {selectedInfo &&
+        typeof document !== 'undefined' &&
+        createPortal(
           <div
-            className="relative max-h-[80vh] w-[calc(100vw-32px)] max-w-[340px] overflow-y-auto rounded-lg border border-[var(--color-border-primary)] bg-[var(--color-bg-primary)] p-5 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-            aria-label="emotion-select-popup"
+            className="fixed inset-0 left-0 right-0 top-0 bottom-0 z-500 flex items-center justify-center bg-black/50"
+            onClick={() => setSelectedInfo(null)}
+            aria-label="emotion-select-overlay"
           >
-            <div className="mb-4 flex items-center justify-between">
-              <h3 className="text-sm font-medium text-[var(--color-text-primary)]">
-                {selectedInfo.label}
-              </h3>
-              <button
-                onClick={() => setSelectedInfo(null)}
-                aria-label="emotion-select-close"
-                className="cursor-pointer rounded p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-overlay-3)] hover:text-[var(--color-text-primary)]"
-              >
-                <X size={18} />
-              </button>
-            </div>
-            <div className="flex flex-col gap-2">
-              {selectedInfo.emotions.map((emotion) => (
-                <div
-                  key={emotion.id}
-                  className="flex items-center justify-between gap-3 rounded-md bg-[var(--color-overlay-2)] px-3 py-2.5"
+            <div
+              className="relative max-h-[80vh] w-[calc(100vw-32px)] max-w-[340px] overflow-y-auto rounded-lg border border-[var(--color-border-primary)] bg-[var(--color-bg-primary)] p-5 shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+              aria-label="emotion-select-popup"
+            >
+              <div className="mb-4 flex items-center justify-between">
+                <h3 className="text-sm font-medium text-[var(--color-text-primary)]">
+                  {selectedInfo.label}
+                </h3>
+                <button
+                  onClick={() => setSelectedInfo(null)}
+                  aria-label="emotion-select-close"
+                  className="cursor-pointer rounded p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-overlay-3)] hover:text-[var(--color-text-primary)]"
                 >
-                  <div className="flex items-center gap-2.5 min-w-0">
-                    <span className="text-xl shrink-0">{emotion.emoji}</span>
-                    <div className="min-w-0">
-                      <p className="text-sm text-[var(--color-text-primary)] truncate">
-                        {emotion.name}
-                      </p>
-                      <p className="text-[11px] text-[var(--color-text-muted)]">
-                        ⚡ {emotion.energyCost}
-                      </p>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => {
-                      onAddToCart(emotion);
-                      setSelectedInfo(null);
-                    }}
-                    aria-label={`add-to-cart-${emotion.id}`}
-                    className="shrink-0 cursor-pointer rounded border border-[var(--color-border-green)] bg-[var(--color-green-overlay-1)] px-3 py-1.5 text-[11px] font-medium text-[var(--color-accent-green)] transition-colors hover:bg-[var(--color-green-overlay-2)]"
+                  <X size={18} />
+                </button>
+              </div>
+              <div className="flex flex-col gap-2">
+                {selectedInfo.emotions.map((emotion) => (
+                  <div
+                    key={emotion.id}
+                    className="flex items-center justify-between gap-3 rounded-md bg-[var(--color-overlay-2)] px-3 py-2.5"
                   >
-                    담기
-                  </button>
-                </div>
-              ))}
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <span className="text-xl shrink-0">{emotion.emoji}</span>
+                      <div className="min-w-0">
+                        <p className="text-sm text-[var(--color-text-primary)] truncate">
+                          {emotion.name}
+                        </p>
+                        <p className="text-[11px] text-[var(--color-text-muted)]">
+                          ⚡ {emotion.energyCost}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => {
+                        onAddToCart(emotion);
+                        setSelectedInfo(null);
+                      }}
+                      aria-label={`add-to-cart-${emotion.id}`}
+                      className="shrink-0 cursor-pointer rounded border border-[var(--color-border-green)] bg-[var(--color-green-overlay-1)] px-3 py-1.5 text-[11px] font-medium text-[var(--color-accent-green)] transition-colors hover:bg-[var(--color-green-overlay-2)]"
+                    >
+                      담기
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/products/src/constants/plutchikWheelConfig.ts
+++ b/products/src/constants/plutchikWheelConfig.ts
@@ -1,54 +1,50 @@
-export interface PlutchikSector {
-  category: string;
-  startAngle: number;
-  colors: [string, string, string]; // [high, middle, low]
-}
+/**
+ * Plutchik 바퀴 SVG 지오메트리
+ *
+ * 감정 데이터(라벨, 색상)는 @shared/constants/categories 참조.
+ * 이 파일은 바퀴 렌더링에 필요한 좌표/경로 계산만 담당.
+ */
+import {
+  BASE_EMOTIONS,
+  INTENSITY_LEVELS,
+  getIntensityColors,
+} from '@shared/constants/categories';
 
-const ANGLE_STEP = 45;
-const ANGLE_OFFSET = -90; // joy starts at 12 o'clock
-
-const SECTOR_ORDER = [
-  'joy',
-  'trust',
-  'fear',
-  'surprise',
-  'sadness',
-  'disgust',
-  'anger',
-  'anticipation',
-] as const;
-
-const SECTOR_COLORS: Record<string, [string, string, string]> = {
-  joy: ['#FFEB3B', '#FFF176', '#FFF9C4'],
-  trust: ['#8BC34A', '#AED581', '#DCEDC8'],
-  fear: ['#4CAF50', '#81C784', '#C8E6C9'],
-  surprise: ['#00BCD4', '#4DD0E1', '#B2EBF2'],
-  sadness: ['#2196F3', '#64B5F6', '#BBDEFB'],
-  disgust: ['#9C27B0', '#BA68C8', '#E1BEE7'],
-  anger: ['#F44336', '#E57373', '#FFCDD2'],
-  anticipation: ['#FF9800', '#FFB74D', '#FFE0B2'],
-};
-
-export const PLUTCHIK_SECTORS: PlutchikSector[] = SECTOR_ORDER.map(
-  (category, i) => ({
-    category,
-    startAngle: ANGLE_OFFSET + i * ANGLE_STEP,
-    colors: SECTOR_COLORS[category],
-  })
-);
-
-// Ring radii: high (innermost) → low (outermost)
-export const RING_RADII: [number, number][] = [
-  [60, 120],   // high
-  [120, 185],  // middle
-  [185, 245],  // low
-];
-
-export const RING_NAMES = ['high', 'middle', 'low'] as const;
+// ─── SVG 상수 ─────────────────────────────────────────
 
 export const CENTER = 250;
 export const VIEW_SIZE = 500;
 export const COMPOSITE_LABEL_RADIUS = 270;
+
+const ANGLE_STEP = 45;
+const ANGLE_OFFSET = -90; // joy = 12시
+
+/** Ring 반경: highest(안쪽) → lowest(바깥쪽) */
+export const RING_RADII: [number, number][] = [
+  [60, 120],   // highest
+  [120, 185],  // middle
+  [185, 245],  // lowest
+];
+
+export const RING_NAMES = INTENSITY_LEVELS;
+
+// ─── 섹터 (BASE_EMOTIONS에서 파생) ───────────────────
+
+export interface PlutchikSector {
+  category: string;
+  startAngle: number;
+  colors: string[];
+}
+
+export const PLUTCHIK_SECTORS: PlutchikSector[] = BASE_EMOTIONS.map(
+  (emotion, i) => ({
+    category: emotion.code,
+    startAngle: ANGLE_OFFSET + i * ANGLE_STEP,
+    colors: getIntensityColors(emotion.code),
+  })
+);
+
+// ─── SVG 경로 유틸 ───────────────────────────────────
 
 function toRadians(deg: number): number {
   return (deg * Math.PI) / 180;
@@ -79,7 +75,6 @@ export function describeArc(
   const outerEnd = polarToCartesian(cx, cy, outerR, endAngle);
   const innerStart = polarToCartesian(cx, cy, innerR, endAngle);
   const innerEnd = polarToCartesian(cx, cy, innerR, startAngle);
-
   const largeArc = endAngle - startAngle > 180 ? 1 : 0;
 
   return [
@@ -94,9 +89,7 @@ export function describeArc(
 export function getSegmentPath(sectorIndex: number, ringIndex: number): string {
   const sector = PLUTCHIK_SECTORS[sectorIndex];
   const [innerR, outerR] = RING_RADII[ringIndex];
-  const startAngle = sector.startAngle;
-  const endAngle = startAngle + ANGLE_STEP;
-  return describeArc(CENTER, CENTER, innerR, outerR, startAngle, endAngle);
+  return describeArc(CENTER, CENTER, innerR, outerR, sector.startAngle, sector.startAngle + ANGLE_STEP);
 }
 
 export function getSegmentCentroid(
@@ -105,15 +98,12 @@ export function getSegmentCentroid(
 ): { x: number; y: number } {
   const sector = PLUTCHIK_SECTORS[sectorIndex];
   const [innerR, outerR] = RING_RADII[ringIndex];
-  const midAngle = sector.startAngle + ANGLE_STEP / 2;
-  const midR = (innerR + outerR) / 2;
-  return polarToCartesian(CENTER, CENTER, midR, midAngle);
+  return polarToCartesian(CENTER, CENTER, (innerR + outerR) / 2, sector.startAngle + ANGLE_STEP / 2);
 }
 
 export function getCompositePosition(
   sectorIndex: number
 ): { x: number; y: number } {
   const sector = PLUTCHIK_SECTORS[sectorIndex];
-  const midAngle = sector.startAngle + ANGLE_STEP;
-  return polarToCartesian(CENTER, CENTER, COMPOSITE_LABEL_RADIUS, midAngle);
+  return polarToCartesian(CENTER, CENTER, COMPOSITE_LABEL_RADIUS, sector.startAngle + ANGLE_STEP);
 }

--- a/shared/components/AppLayout.tsx
+++ b/shared/components/AppLayout.tsx
@@ -7,7 +7,7 @@ interface AppLayoutProps {
 
 function AppLayout({ subtitle, children }: AppLayoutProps) {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col overflow-hidden">
       <header className="flex items-center justify-between border-b border-[var(--color-border-primary)] bg-black px-3 md:px-6 py-2">
         <h1 className="font-normal tracking-wider text-[var(--color-text-primary)]">
           Booked by Feelings
@@ -19,7 +19,7 @@ function AppLayout({ subtitle, children }: AppLayoutProps) {
         )}
       </header>
 
-      <main className="min-h-0 flex-1 p-3 md:p-6">{children}</main>
+      <main className="min-h-0 flex-1 p-3 md:p-6 ">{children}</main>
 
       <footer className="border-t border-[var(--color-border-primary)] bg-black  p-4 text-center font-normal">
         <p className="text-sm text-[var(--color-text-muted)]">

--- a/shared/constants/categories.ts
+++ b/shared/constants/categories.ts
@@ -1,77 +1,169 @@
 /**
- * Category labels mapping from category codes to Korean display names
+ * Plutchik 감정 시스템 — 단일 소스
+ *
+ * 구조:
+ *   BASE_EMOTIONS      8개 기본 감정 (시계방향, 12시=joy)
+ *     └ intensities[]  3단계 강도 (highest→middle→lowest, 안쪽→바깥쪽)
+ *   COMPOSITE_EMOTIONS 8개 복합 감정 (인접 기본 감정 사이)
+ *   INTENSITY_LEVELS   강도 단계 순서
+ *
+ * 다른 파일에서는 여기서 export된 상수/헬퍼만 사용합니다.
  */
-export const CATEGORY_LABELS: Record<string, string> = {
-  joy: '기쁨',
-  sadness: '슬픔',
-  anger: '분노',
-  fear: '두려움',
-  disgust: '혐오',
-  surprise: '놀람',
-  trust: '신뢰',
-  anticipation: '기대',
-  love: '사랑',
-  obsession: '집착',
-  anxiety: '불안',
-  jealousy: '질투',
-  disappointment: '실망',
-  contempt: '경멸',
-  discouragement: '낙담',
-  guilt: '죄책감',
-  hope: '희망',
-  anticipation: '기대',
-  submission: '복종',
-  awe: '경외',
-  disapproval: '비난',
-  remorse: '회한',
-  aggressiveness: '공격성',
-  optimism: '낙관',
-};
 
-export const BASE_CATEGORIES = [
-  'joy',
-  'sadness',
-  'anger',
-  'fear',
-  'disgust',
-  'surprise',
-  'trust',
-  'anticipation',
-] as const;
+// ─── 타입 ────────────────────────────────────────────
 
-export const COMPOSITE_CATEGORIES = [
-  'love',
-  'obsession',
-  'anxiety',
-  'jealousy',
-  'disappointment',
-  'contempt',
-  'discouragement',
-  'guilt',
-  'hope',
-  'submission',
-  'awe',
-  'disapproval',
-  'remorse',
-  'aggressiveness',
-  'optimism',
-] as const;
+export interface EmotionIntensity {
+  ko: string;
+  en: string;
+  color: string;
+}
+
+export interface BaseEmotion {
+  code: string;
+  ko: string;
+  /** highest(안쪽) → lowest(바깥쪽) 순서 */
+  intensities: [EmotionIntensity, EmotionIntensity, EmotionIntensity];
+}
+
+export interface CompositeEmotion {
+  code: string;
+  ko: string;
+  /** 인접한 두 기본 감정 [시계방향 앞, 뒤] */
+  pair: [string, string];
+}
+
+// ─── 강도 단계 ───────────────────────────────────────
+
+export const INTENSITY_LEVELS = ['high', 'middle', 'low'] as const;
+export type IntensityLevel = (typeof INTENSITY_LEVELS)[number];
+
+// ─── 8개 기본 감정 (시계방향, 12시=joy) ──────────────
+//
+//  각 행: { ko, en, color }  ← highest → middle → lowest
+
+export const BASE_EMOTIONS: BaseEmotion[] = [
+  {
+    code: 'joy', ko: '기쁨',
+    intensities: [
+      { ko: '황홀',   en: 'ecstasy',      color: '#F9A825' },
+      { ko: '기쁨',   en: 'joy',          color: '#FFF176' },
+      { ko: '평온',   en: 'serenity',     color: '#FFFDE7' },
+    ],
+  },
+  {
+    code: 'trust', ko: '신뢰',
+    intensities: [
+      { ko: '경탄',   en: 'admiration',   color: '#558B2F' },
+      { ko: '신뢰',   en: 'trust',        color: '#AED581' },
+      { ko: '수용',   en: 'acceptance',   color: '#F1F8E9' },
+    ],
+  },
+  {
+    code: 'fear', ko: '두려움',
+    intensities: [
+      { ko: '공포',   en: 'terror',       color: '#2E7D32' },
+      { ko: '두려움', en: 'fear',         color: '#81C784' },
+      { ko: '우려',   en: 'apprehension', color: '#E8F5E9' },
+    ],
+  },
+  {
+    code: 'surprise', ko: '놀람',
+    intensities: [
+      { ko: '경악',   en: 'amazement',    color: '#00838F' },
+      { ko: '놀람',   en: 'surprise',     color: '#4DD0E1' },
+      { ko: '산만',   en: 'distraction',  color: '#E0F7FA' },
+    ],
+  },
+  {
+    code: 'sadness', ko: '슬픔',
+    intensities: [
+      { ko: '비탄',   en: 'grief',        color: '#1565C0' },
+      { ko: '슬픔',   en: 'sadness',      color: '#64B5F6' },
+      { ko: '수심',   en: 'pensiveness',  color: '#E3F2FD' },
+    ],
+  },
+  {
+    code: 'disgust', ko: '혐오',
+    intensities: [
+      { ko: '증오',   en: 'loathing',     color: '#6A1B9A' },
+      { ko: '혐오',   en: 'disgust',      color: '#BA68C8' },
+      { ko: '권태',   en: 'boredom',      color: '#F3E5F5' },
+    ],
+  },
+  {
+    code: 'anger', ko: '분노',
+    intensities: [
+      { ko: '격분',   en: 'rage',         color: '#C62828' },
+      { ko: '분노',   en: 'anger',        color: '#E57373' },
+      { ko: '성가심', en: 'annoyance',    color: '#FFEBEE' },
+    ],
+  },
+  {
+    code: 'anticipation', ko: '기대',
+    intensities: [
+      { ko: '경계',   en: 'vigilance',    color: '#E65100' },
+      { ko: '기대',   en: 'anticipation', color: '#FFB74D' },
+      { ko: '관심',   en: 'interest',     color: '#FFF3E0' },
+    ],
+  },
+];
+
+// ─── 8개 복합 감정 (인접 기본 감정 사이, 시계방향) ───
+
+export const COMPOSITE_EMOTIONS: CompositeEmotion[] = [
+  { code: 'love',            ko: '사랑',   pair: ['joy', 'trust'] },
+  { code: 'submission',      ko: '복종',   pair: ['trust', 'fear'] },
+  { code: 'awe',             ko: '경외',   pair: ['fear', 'surprise'] },
+  { code: 'disapproval',     ko: '비난',   pair: ['surprise', 'sadness'] },
+  { code: 'remorse',         ko: '회한',   pair: ['sadness', 'disgust'] },
+  { code: 'contempt',        ko: '경멸',   pair: ['disgust', 'anger'] },
+  { code: 'aggressiveness',  ko: '공격성', pair: ['anger', 'anticipation'] },
+  { code: 'optimism',        ko: '낙관',   pair: ['anticipation', 'joy'] },
+];
+
+// ─── 파생 상수 (위 마스터 데이터에서 자동 생성) ──────
+
+/** 카테고리 코드 → 한글 라벨 (기본 + 강도별 + 복합 전체) */
+export const CATEGORY_LABELS: Record<string, string> = Object.fromEntries([
+  ...BASE_EMOTIONS.map((e) => [e.code, e.ko]),
+  ...BASE_EMOTIONS.flatMap((e) => e.intensities.map((i) => [i.en, i.ko])),
+  ...COMPOSITE_EMOTIONS.map((e) => [e.code, e.ko]),
+]);
+
+/** 기본 카테고리 코드 배열 */
+export const BASE_CATEGORIES = BASE_EMOTIONS.map((e) => e.code);
+
+/** 복합 카테고리 코드 배열 */
+export const COMPOSITE_CATEGORIES = COMPOSITE_EMOTIONS.map((e) => e.code);
+
+/** 복합 감정 → 인접 기본 감정 쌍 */
+export const COMPOSITE_CATEGORY_PAIRS: Record<string, [string, string]> = Object.fromEntries(
+  COMPOSITE_EMOTIONS.map((e) => [e.code, e.pair])
+);
+
+// ─── 헬퍼 함수 ──────────────────────────────────────
+
+const baseIndex = new Map(BASE_EMOTIONS.map((e, i) => [e.code, i]));
 
 export function isBaseCategory(category?: string | null): boolean {
-  return !!category && BASE_CATEGORIES.includes(category as (typeof BASE_CATEGORIES)[number]);
+  return !!category && baseIndex.has(category);
 }
 
 export function isCompositeCategory(category?: string | null): boolean {
-  return !!category && COMPOSITE_CATEGORIES.includes(category as (typeof COMPOSITE_CATEGORIES)[number]);
+  return !!category && COMPOSITE_EMOTIONS.some((e) => e.code === category);
 }
 
-export const COMPOSITE_CATEGORY_PAIRS: Record<string, [string, string]> = {
-  love: ['joy', 'trust'],
-  submission: ['trust', 'fear'],
-  awe: ['fear', 'surprise'],
-  disapproval: ['surprise', 'sadness'],
-  remorse: ['sadness', 'disgust'],
-  contempt: ['disgust', 'anger'],
-  aggressiveness: ['anger', 'anticipation'],
-  optimism: ['anticipation', 'joy'],
-};
+/** 기본 감정의 강도별 라벨 조회 */
+export function getIntensityLabel(
+  categoryCode: string,
+  ringIndex: number
+): EmotionIntensity | undefined {
+  const base = BASE_EMOTIONS.find((e) => e.code === categoryCode);
+  return base?.intensities[ringIndex];
+}
+
+/** 기본 감정의 색상 배열 (highest→lowest) */
+export function getIntensityColors(categoryCode: string): string[] {
+  const base = BASE_EMOTIONS.find((e) => e.code === categoryCode);
+  return base ? base.intensities.map((i) => i.color) : [];
+}

--- a/shared/types/api.ts
+++ b/shared/types/api.ts
@@ -17,7 +17,7 @@ export interface Emotion {
   id: number;
   name: string;
   emoji: string;
-  intensity: 'low' | 'middle' | 'high';
+  intensity: 'high' | 'middle' | 'low';
   category: string;
   description: string;
   story: string;


### PR DESCRIPTION
# 기능 구현

## 1. 감정 바퀴 뷰 추가

<img width="1403" height="840" alt="image" src="https://github.com/user-attachments/assets/ffb83f3f-93b1-42b3-b299-ce47278b7df4" />

### 탭 구성
- 감정 바퀴(기본) / 목록
<img width="160" height="49" alt="image" src="https://github.com/user-attachments/assets/4bacb5fc-91ba-4791-b0ad-668ae066bcaf" />

### 섹터 단위 시각화

- 섹터 선택 상태 표시: 섹터 클릭 시 low-middle-high 상태 선택

<img width="404" height="368" alt="image" src="https://github.com/user-attachments/assets/223c0cb2-fdf0-407d-aadd-7dfdfc30680d" />

- 상태가 선택될 시, 감정 아이템이 2개 이상 존재하면 팝업 출력

<img width="400" height="297" alt="image" src="https://github.com/user-attachments/assets/ff207c18-089a-4025-b8ea-1d516663d342" />

- 장바구니에 추가된 감정 하이라이트

<img width="346" height="274" alt="image" src="https://github.com/user-attachments/assets/54c5ffa2-322b-4d21-b983-1c3d765345e8" />


## 2. 감정 데이터 구조/타입 정리

- 감정 카테고리 구조 통일 및 intensity 표준화
- 감정 매핑 라벨 정리
- DB에 값 삽입